### PR TITLE
add moderatorQuarterPoint (Needed for DGDG-434)

### DIFF
--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -166,6 +166,7 @@ const serializeAddress = function (address) {
     address.lockedDgd = new BigNumber(address.lockedDgd);
     address.reputationPoint = new BigNumber(address.reputationPoint);
     address.quarterPoint = new BigNumber(address.quarterPoint);
+    address.moderatorQuarterPoint = new BigNumber(address.moderatorQuarterPoint);
   }
 
   return address;
@@ -237,6 +238,7 @@ const deserializeAddress = function (address) {
     address.lockedDgd = ofOne(address.lockedDgd, denominators.DGD);
     address.reputationPoint = ofOne(address.reputationPoint, denominators.REPUTATION_POINT);
     address.quarterPoint = ofOne(address.quarterPoint, denominators.QUARTER_POINT);
+    address.moderatorQuarterPoint = ofOne(address.moderatorQuarterPoint, denominators.QUARTER_POINT);
     address.claimableDgx = ofOne(address.claimableDgx, denominators.DGX);
   }
 

--- a/scripts/addresses.js
+++ b/scripts/addresses.js
@@ -46,6 +46,7 @@ const getAddressObject = (userInfo) => {
     reputationPoint: userInfo[8].toString(),
     quarterPoint: userInfo[9].toString(),
     claimableDgx: userInfo[10].toString(),
+    moderatorQuarterPoint: userInfo[11].toString(),
   };
 };
 

--- a/types/user.js
+++ b/types/user.js
@@ -26,6 +26,9 @@ const typeDef = gql`
     # User's current quarterly points
     quarterPoint: BigNumber
 
+    # User's current moderator quarter points
+    moderatorQuarterPoint: BigNumber
+
     # A flag to indicate if the current user is a moderator
     isModerator: Boolean
 
@@ -36,6 +39,7 @@ const typeDef = gql`
 
 const dgd = value => (value === null || value === undefined ? null : ofOne(value, denominators.DGD));
 const reputation = value => (value ? ofOne(value, denominators.REPUTATION_POINT) : null);
+const quarterPoint = value => (value ? ofOne(value, denominators.QUARTER_POINT) : null);
 
 const resolvers = {
   User: {
@@ -52,7 +56,10 @@ const resolvers = {
       return reputation(user.reputationPoint);
     },
     quarterPoint(user) {
-      return reputation(user.quarterPoint);
+      return quarterPoint(user.quarterPoint);
+    },
+    moderatorQuarterPoint(user) {
+      return quarterPoint(user.moderatorQuarterPoint);
     },
   },
 };


### PR DESCRIPTION
`/address/:address` returns a field `moderatorQuarterPoint`